### PR TITLE
Fix ordering of newly fetched episodes

### DIFF
--- a/src/BuildCast/ViewModels/FeedDetailsViewModel.cs
+++ b/src/BuildCast/ViewModels/FeedDetailsViewModel.cs
@@ -18,6 +18,7 @@ using BuildCast.DataModel;
 using BuildCast.Helpers;
 using BuildCast.Services.Navigation;
 using Windows.UI.Xaml.Navigation;
+using System.Linq;
 
 namespace BuildCast.ViewModels
 {
@@ -75,6 +76,8 @@ namespace BuildCast.ViewModels
         public async Task<int> RefreshData()
         {
             var newEpisodes = await CurrentFeed.GetNewEpisodesAsync();
+            newEpisodes = newEpisodes.OrderBy(e => e.PublishDate).ToList();
+
             foreach (var episode in newEpisodes)
             {
                 EpisodeData.Insert(0, episode);


### PR DESCRIPTION
Since episodes are inserted to the front of the list, they need to be in ascending order by PublishDate so that they are stacked and display in descending order.  I know, sounds backwards.