### PR TITLE
Set the "Add Bookmark" as default button

### DIFF
--- a/src/BuildCast/Views/Player.xaml
+++ b/src/BuildCast/Views/Player.xaml
@@ -148,6 +148,7 @@
             Background="{ThemeResource AppBarBackgroundThemeBrush}"
             BorderThickness="0,0,0,0"
             CloseButtonText="Cancel"
+            DefaultButton="Primary"
             PrimaryButtonCommand="{x:Bind AddBookmarkCommand}"
             PrimaryButtonText="Add bookmark">
             <ContentDialog.Content>


### PR DESCRIPTION
Enter key is not working for add a new bookmark. I fixed it setting the primary button as default in ContentDialog on Player.xaml.

This is the result: 

![image](https://user-images.githubusercontent.com/1033649/36572946-31cee6fe-181d-11e8-95bb-4a3eb3af418a.png)
