### PR TITLE
Bugfixes and basic Drag & Drop

### DIFF
--- a/src/BuildCast/Helpers/TitleBarHelper.cs
+++ b/src/BuildCast/Helpers/TitleBarHelper.cs
@@ -10,9 +10,11 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using System;
 using System.ComponentModel;
 using Windows.ApplicationModel.Core;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 
 namespace BuildCast.Helpers
 {
@@ -22,6 +24,7 @@ namespace BuildCast.Helpers
         private static CoreApplicationViewTitleBar _coreTitleBar;
         private Thickness _titlePosition;
         private Visibility _titleVisibility;
+        private int _extraPadding;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TitleBarHelper"/> class.
@@ -103,7 +106,22 @@ namespace BuildCast.Helpers
             // top position should be 6 pixels for a 32 pixel high titlebar hence scale by actual height
             var correctHeight = height / 32 * 6;
 
-            return new Thickness(leftPosition + 12, correctHeight, 0, 0);
+            return new Thickness(leftPosition + 12 + _extraPadding, correctHeight, 0, 0);
+        }
+
+        internal void NavDisplayModeChanged(NavigationView sender, NavigationViewDisplayModeChangedEventArgs args)
+        {
+            switch (args.DisplayMode)
+            {
+                case NavigationViewDisplayMode.Compact:
+                    _extraPadding = 50;
+                    break;
+                default:
+                    _extraPadding = 0;
+                    break;
+            }
+
+            TitlePosition = CalculateTilebarOffset(_coreTitleBar.SystemOverlayLeftInset, _coreTitleBar.Height);
         }
     }
 }

--- a/src/BuildCast/Views/NavigationRoot.xaml
+++ b/src/BuildCast/Views/NavigationRoot.xaml
@@ -31,7 +31,7 @@
                    Fill="{StaticResource NavigationViewDefaultPaneBackground}" 
                    HorizontalAlignment="Left" Height="1000" Width="48"/>
 
-        <RS3:NavigationView IsSettingsVisible="True" x:Name="navview" AlwaysShowHeader="False" ItemInvoked="Navview_ItemInvoked">
+        <RS3:NavigationView IsSettingsVisible="True" x:Name="navview" AlwaysShowHeader="False" ItemInvoked="Navview_ItemInvoked" DisplayModeChanged="navview_DisplayModeChanged">
             <RS3:NavigationView.MenuItems>
                 <RS3:NavigationViewItem Content="Browse videos" IsSelected="True">
                     <RS3:NavigationViewItem.Icon>

--- a/src/BuildCast/Views/NavigationRoot.xaml.cs
+++ b/src/BuildCast/Views/NavigationRoot.xaml.cs
@@ -199,5 +199,10 @@ namespace BuildCast.Views
             return d.ToString("d");
         }
         #endregion
+
+        private void navview_DisplayModeChanged(NavigationView sender, NavigationViewDisplayModeChangedEventArgs args)
+        {
+            TitleBarHelper.Instance.NavDisplayModeChanged(sender, args);
+        }
     }
 }

--- a/src/BuildCast/Views/Notes.xaml
+++ b/src/BuildCast/Views/Notes.xaml
@@ -119,8 +119,10 @@
                 ItemClick="NotesListView_Tapped"
                 IsItemClickEnabled="True"
                 SelectionMode="None"
+             CanDragItems="True"
             animations:Implicit.ShowAnimations="{StaticResource DefaultListShowAnimations}"
             animations:Implicit.HideAnimations="{StaticResource DefaultListHideAnimations}"
+            DragItemsStarting="notesListView_DragItemsStarting"
                 >
             <ListView.ItemContainerStyle>
                 <Style TargetType="ListViewItem">

--- a/src/BuildCast/Views/Notes.xaml.cs
+++ b/src/BuildCast/Views/Notes.xaml.cs
@@ -11,13 +11,11 @@
 // ******************************************************************
 
 using BuildCast.DataModel;
-using BuildCast.Helpers;
 using BuildCast.Services.Navigation;
 using BuildCast.ViewModels;
+using Windows.ApplicationModel.DataTransfer;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Hosting;
-using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Navigation;
 
 namespace BuildCast.Views
@@ -168,6 +166,28 @@ namespace BuildCast.Views
         private void MenuFlyoutItem_Click(object sender, RoutedEventArgs e)
         {
             ReLoadNotes();
+        }
+
+        private async void notesListView_DragItemsStarting(object sender, DragItemsStartingEventArgs e)
+        {
+            // Set the content of the DataPackage
+            if (e.Items.Count > 0)
+            {
+                var noteParameter = e.Items[0] as dynamic;
+
+                if (noteParameter != null)
+                {
+                    switch (noteParameter.Type)
+                    {
+                        case "Bookmark":
+                            e.Data.SetText($"{noteParameter.Time}\t{noteParameter.Episode}\t{noteParameter.NoteText}\n");
+                            break;
+                    }
+                }
+            }
+
+            // As we want our Reference list to say intact, we only allow Copy
+            e.Data.RequestedOperation = DataPackageOperation.Copy;
         }
     }
 }

--- a/src/BuildCast/Views/PopupPlayer.xaml
+++ b/src/BuildCast/Views/PopupPlayer.xaml
@@ -24,6 +24,6 @@
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" x:Name="theGrid">
         <Rectangle x:Name="gl" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"></Rectangle>
         <Rectangle SizeChanged="PlayerHolder_SizeChanged" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" x:Name="playerHolder" Margin="0,0,0,0"></Rectangle>
-        <Button x:Name="btnexit" Click="Btnexit_LeaveCompactMode" VerticalAlignment="Bottom" HorizontalAlignment="Center">Exit</Button>
+        <Button x:Name="btnexit" Click="Btnexit_LeaveCompactMode" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="10,10,0,0">Exit</Button>
     </Grid>
 </Page>


### PR DESCRIPTION
- Fix the positioning of the titlebar text when navigation view is in minimal mode
- Fix the positioning of the Exit button in compact overlay
- Add support for drag and drop from notes to other apps like onenote.  Only works for bookmarks, not ink notes.